### PR TITLE
tmp5

### DIFF
--- a/packages/canvas-media/src/__tests__/UploadMedia.test.tsx
+++ b/packages/canvas-media/src/__tests__/UploadMedia.test.tsx
@@ -300,12 +300,13 @@ describe('UploadMedia: ComputerPanel', () => {
     })
   })
   describe('shows closed captions panel', () => {
+    // @ts-expect-error
     let user
 
     beforeEach(() => {
       user = userEvent.setup()
       vi.mock('../ClosedCaptionCreator', () => ({
-        default: () => <div data-testid="ClosedCaptionPanel" />
+        default: () => <div data-testid="ClosedCaptionPanel" />,
       }))
     })
 
@@ -317,7 +318,8 @@ describe('UploadMedia: ComputerPanel', () => {
     it('shows closed captions panel when uploading videos', async () => {
       const aFile = new File(['foo'], 'foo.mov', {
         type: 'video/quicktime',
-        title: 'foo.mov'
+        // @ts-expect-error
+        title: 'foo.mov',
       })
 
       const {getByTestId, findByTestId} = renderPanel({
@@ -327,6 +329,7 @@ describe('UploadMedia: ComputerPanel', () => {
 
       const ccCheckbox = getByTestId('mediaTracks-checkbox').querySelector('input[type="checkbox"]')
       if (!ccCheckbox) throw new Error('Checkbox input not found')
+      // @ts-expect-error
       await user.click(ccCheckbox)
 
       // Wait for panel to appear
@@ -337,7 +340,8 @@ describe('UploadMedia: ComputerPanel', () => {
     it('shows closed captions panel when uploading audios', async () => {
       const aFile = new File(['foo'], 'foo.mp3', {
         type: 'audio/mp3',
-        title: 'foo.mp3'
+        // @ts-expect-error
+        title: 'foo.mp3',
       })
       const {getByTestId, findByTestId} = renderPanel({
         theFile: aFile,
@@ -346,6 +350,7 @@ describe('UploadMedia: ComputerPanel', () => {
 
       const ccCheckbox = getByTestId('mediaTracks-checkbox').querySelector('input[type="checkbox"]')
       if (!ccCheckbox) throw new Error('Checkbox input not found')
+      // @ts-expect-error
       await user.click(ccCheckbox)
 
       // Wait for panel to appear

--- a/ui/features/outcome_management/react/MasteryCalculation/__tests__/index.test.jsx
+++ b/ui/features/outcome_management/react/MasteryCalculation/__tests__/index.test.jsx
@@ -19,6 +19,8 @@
 import React from 'react'
 import {act, render as rtlRender, waitFor, fireEvent} from '@testing-library/react'
 import {MockedProvider} from '@apollo/client/testing'
+import {http} from 'msw'
+import {setupServer} from 'msw/node'
 import OutcomesContext from '@canvas/outcomes/react/contexts/OutcomesContext'
 import {
   ACCOUNT_OUTCOME_CALCULATION_QUERY,
@@ -29,7 +31,19 @@ import {masteryCalculationGraphqlMocks} from '@canvas/outcomes/mocks/Outcomes'
 
 jest.useFakeTimers()
 
+const server = setupServer()
+
 describe('MasteryCalculation', () => {
+  beforeAll(() => {
+    server.listen({
+      onUnhandledRequest: 'error',
+    })
+  })
+
+  afterAll(() => {
+    server.close()
+  })
+
   beforeEach(() => {
     window.ENV = {
       PROFICIENCY_CALCULATION_METHOD_ENABLED_ROLES: [
@@ -56,6 +70,7 @@ describe('MasteryCalculation', () => {
 
   afterEach(() => {
     window.ENV = null
+    server.resetHandlers()
   })
 
   const render = (
@@ -71,6 +86,17 @@ describe('MasteryCalculation', () => {
     )
   }
 
+  function setupSubmissionHandler(contextType, contextId, payload) {
+    server.use(
+      http.post(`/${contextType.toLowerCase()}s/${contextId}/outcome_calculation_method`, async ({request}) => {
+        const formData = await request.formData()
+        return new Response(JSON.stringify(payload), {
+          headers: {'Content-Type': 'application/json'},
+        })
+      })
+    )
+  }
+
   it('loads proficiency data for Account', async () => {
     const {getByDisplayValue} = render(<MasteryCalculation />)
     await act(async () => jest.runAllTimers())
@@ -78,6 +104,11 @@ describe('MasteryCalculation', () => {
   })
 
   it('loads calculation data for Course', async () => {
+    setupSubmissionHandler('Course', '12', {
+      calculation_method: 'decaying_average',
+      calculation_int: 65,
+    })
+
     const {findByDisplayValue} = render(<MasteryCalculation />, {
       contextType: 'Course',
       contextId: '12',
@@ -165,6 +196,14 @@ describe('MasteryCalculation', () => {
         result: updateCall,
       },
     ]
+
+    beforeEach(() => {
+      setupSubmissionHandler('Account', '11', {
+        calculation_method: variables.calculationMethod,
+        calculation_int: variables.calculationInt,
+      })
+    })
+
     it('submits a request when calculation method is saved', async () => {
       const {getByText, findByLabelText} = render(<MasteryCalculation />, {mocks: updateMocks})
       await act(async () => jest.runAllTimers())


### PR DESCRIPTION
- **stabilize external_tool_importer and AuthorInfo test**
- **Use newError form message type**
- **Add isRequired prop where possible in course copy**
- **Data fix for Twitter auth providers**
- **fix package translations build again (take 2)**
- **Add loading spinner for content migrations table initial state**
- **Remove Unnecessary LIME HTML Escaping**
- **Fix search bar refreshing page on enter key press**
- **expose LTI Registrations API documentation**
- **document Developer Keys endpoints**
- **document LTI Launch Definitions endpoint**
- **Display hidden module menu items options**
- **increase jest nodes to 16 in frontend GitHub Action**
- **Delete failing and unnecessary LIME test**
- **Update Context Index**
- **gradebook: filter on non-col groups when needed**
- **add self assessment settings to show assignments**
- **stabilize MessageDetailContainer.comments.test.jsx (refs CFA-71)**
- **Allow hidden groups to be assigned to modules REST**
- **set lti_oidc_missing_cookie_retry FF shadow: true**
- **stabilize NameLink.test.tsx**
- **stabilize GradingSchemeTable.test.tsx (refs CFA-71)**
- **stabilize lti.put_data.test.js (refs CFA-71)**
- **stabilize utils.js in k5 (refs CFA-71)**
- **stabilize ScoreToUngradedManager.test.tsx (refs CFA-71)**
- **stabilize GradebookExportManager.test.js (refs CFA-71)**
- **stabilize external_tool_importer.test.tsx**
- **stabilize TotalGradeColumnHeader.test.jsx (refs CFA-71)**
- **stabilize RosterCard.test.jsx**
- **stabilize ContextModulesHeader.test.tsx (refs CFA-71)**
- **stabilize EnrollmentTreeGroup.test.tsx (refs CFA-71)**
- **stabilize MessageDetailItem.test.jsx (refs CFA-71)**
- **stabilize DiscussionTopicContainer.test.jsx**
- **stabilize DataRow.test.jsx (refs CFA-71)**
- **stabilize EnhancedActionMenu.test.tsx (refs CFA-71)**
- **stabilize FileOptionsCollection.test.js (refs CFA-71)**
- **stabilize actions.test.js in add-people (ref CFA-71)**
- **stabilize BBBModalOptions.test.jsx**
- **stabilize ContextModulesPublishIcon.test.tsx (refs CFA-71)**
- **stabilize SpeedGraderProvisionalGradeSelector.test.jsx (refs CFA-71)**
- **stabilize EditAssignment.test.jsx**
- **stabilize DatetimeField.test.js (refs CFA-71)**
- **stabilize EnhancedIndividualGradebook.test.tsx**
- **suppress TS errors in ui/features/login/index.ts**
- **WIP: use flushSync**
- **stabilize platform_storage.test.js (refs CFA-71)**
- **stabilize RestrictedRadioButtons.test.jsx**
- **stabilize EventDataSource.test.js (refs CFA-71)**
- **stabilize reducer.test.js in add-people (refs CFA-71)**
- **stabilize PastGlobalAnnouncements.test.jsx (refs CFA-71)**
- **stabilize CourseActivitySummaryStore.test.js (refs CFA-71)**
- **stabilize SubmissionTrayRadioInput.test.tsx (refs CFA-71)**
- **stabilize CanvasMediaPlayer.test.jsx (refs CFA-71)**
- **stabilize ItemCog.test.jsx**
- **stabilize header.test.tsx in course_paces**
- **add UserPrincipalName (UPN) for Microsoft login**
- **stabilize ExternalToolsTableRow.test.jsx**
- **stabilize CourseImportPanel.test.jsx**
- **stabilize AccountGradingPeriod.test.jsx (refs CFA-71)**
- **stabilize OutcomeManagement.test.jsx (refs CFA-71)**
- **stabilize app.test.tsx in course_paces (refs CFA-71)**
- **stabilize settings.test.tsx in course_paces (refs CFA-71)**
- **stabilize course_copy.test.tsx (refs CFA-71)**
- **allow current_context to be set for account admins**
- **stabilize initMutexes.test.js (refs CFA-71)**
- **remove FF lti_resource_links_api**
- **stabilize, typescriptify FileOptionsCollection.test.ts (refs CFA-71)**
- **stabilize SpeedGraderSelectMenu.test.js (refs CFA-71)**
- **stabilize GradebookExportManager.test.js (refs CFA-71)**
- **stabilize index.test.js in permissions (refs CFA-71)**
- **split out, revamp MessageStudents.test.jsx**
- **tweak some tests**
- **split out, stabilize CalendarEventDetailsForm2.test.jsx (refs CFA-71)**
- **stabilize K5Dashboard.test.jsx (refs CFA-71)**
- **[i18n] Update package translations**
- **[i18n] Update canvas-media translations.**
- **[i18n] Update RCE translations.**
- **rewrite restore user/course search form (5VPAT)**
- **spec: add "submit's queue and list migrations" test case**
- **Return better error messages for JWT validation errors**
- **tweak GradebookExportManager.test.js**
- **stabilize StudentViewIntegration.test.jsx (refs CFA-71)**
- **Use 'newError' form message type in copy course**
- **split out, stabilize GradebookExportManager.test.js (refs CFA-71)**
- **stabilize Conference.test.jsx (refs CFA-71)**
- **stabilize HighContrastModeToggle.test.jsx (refs CFA-71)**
- **Change day substitution remove button**
- **fix TS type checking in the build**
- **split out StudentContent.test.jsx**
- **replace done() callback with promise in axios.test.js (refs CFA-72)**
- **use single rslib config for k5uploader**
- **tweak existing Platform Notice claims**
- **send LTI 1.3 ContextCopy notice in course copy**
- **requeue throttled live events**
- **Don't allow accessing home tab**
- **Bump InstUI patch version**
- **Change use of ReactDOM.render to createroot**
- **5VPAT: Add Form Validation to Auto Assign Peer Review**
- **stabilize header.test.tsx in course_paces**
- **add checkbox to people page**
- **Updates According to New LP LTI Data Payload**
- **tweak vitest config**
- **tweak .dependency-cruiser.js paths**
- **add tooltip for disabled self assessment checkbox**
- **doc: clarify assignment submission criteria**
- **change validation message on datetime DateInput**
- **add package tests to frontend.yml**
- **Update package translation file paths and imports**
- **Add Action Menu UI**
- **rubocop: disable Performance/CollectionLiteralInLoop in specs**
- **Create Bulk Actions Buttons**
- **replace done.fail with promises in tests**
- **stabilize MessageDetailContainer.comments.test.jsx**
- **split out RCEWrapper.test.jsx tests**
- **upgrade caniuse-lite version**
- **upgrade vitest**
- **stabilize AccountGradingPeriod.test.jsx**
- **add note about mockResolvedValue and mockImplementation**
- **remove FFs lti_log_launches and lti_log_launches_site_admin**
- **spec: add "shows LTI view when LTI tool selected" test case**
- **add validator base for Horizon courses**
- **hide tabs for horizon courses**
- **hide Overview elements for horizon courses**
- **update el translation**
- **update fa translation**
- **update he translation**
- **update hu translation**
- **update hy translation**
- **update ko translation**
- **update nn translation**
- **update tr translation**
- **update uk translation**
- **fix unreliable limit clause**
- **restore ad-hoc overrides when rolling back sis imports**
- **remove FF assignment_submission_type_card**
- **Add documented keyboard shortcuts to Discussions part 1**
- **Fix SG prev/next buttons for SG2**
- **Add crosslisted info to orginal course sections**
- **Add People Page Modernization FF**
- **Create bulk manage groups endpoint**
- **fix criteria column name in rubric table**
- **Add error-outline class for form validations**
- **Edit shared checkpoint submission boxes**
- **Validation for: Student Annotation File Upload, Usage Rights**
- **stabilize two test files (refs CFA-71)**
- **Add reviewee validation for peer_reviews**
- **stabilize DiscussionThreadContainer.test.jsx (refs CFA-71)**
- **Add validation to un\publish assignment.**
- **5VPAT: add course_section_dates validation**
- **Clear table selection on pagination**
- **test rce along with other packages; add nodes**
- **stabilize StudentViewIntegration.test.jsx (refs CFA-71)**
- **Expose 'assign_to_differentiation_tags' to ENV**
- **stabilize UsageRightsDialog.test.jsx (refs CFA-71)**
- **add partial for plugins to add additional settings for all auth providers**
- **stabilize two test files (2) (refs CFA-71)**
- **remove FF update_unified_tool_id**
- **split out DiscussionRow.test.jsx**
- **remove FF require_permission_for_app_center_token**
- **remove lti_migration_info FF**
- **stabilize MessageDetailContainer.comments.test.jsx**
- **Fix triggering submission lifecycle manager after import**
- **stabilize index.test.jsx in MasteryCalculation**
- **Populate H2 in new modules**
- **use tsc instead of rslib with k5uploader**
- **spec: add "shift dates" test case**
- **Refactor Student Competency Report Generation**
- **use tsc in canvas-media**
- **stabilize Grid.test.jsx (refs CFA-71)**
- **Optimize Student Competency Report generation**
- **stabilize index.test.jsx in group-modal (rfs CFA-71)**
- **Optimize outcome_order method**
- **Close button in Translation module**
- **disable peer reviews in CLX courses**
- **Author label scrollbar fix**
- **stabilize MessageDetailContainer.comments.test.jsx**
- **hide User Profile button if user is not logged in**
- **stabilize index.test.lsx in MasteryCalculation**
