### PR TITLE
CFA-438: Rename student assignment GraphQL fragments

### DIFF
--- a/ui/shared/assignments/graphql/student/AssessmentRequest.js
+++ b/ui/shared/assignments/graphql/student/AssessmentRequest.js
@@ -21,7 +21,7 @@ import {shape, string} from 'prop-types'
 
 export const AssessmentRequest = {
   fragment: gql`
-    fragment AssessmentRequest on AssessmentRequest {
+    fragment StudentAssessmentRequest on AssessmentRequest {
       anonymizedUser {
         _id
         displayName: shortName

--- a/ui/shared/assignments/graphql/student/Assignment.js
+++ b/ui/shared/assignments/graphql/student/Assignment.js
@@ -28,7 +28,7 @@ import {Submission} from './Submission'
 
 export const Assignment = {
   fragment: gql`
-    fragment Assignment on Assignment {
+    fragment StudentAssignment on Assignment {
       _id
       allowedAttempts
       allowedExtensions
@@ -42,7 +42,7 @@ export const Assignment = {
       gradeGroupStudentsIndividually
       groupCategoryId
       groupSet {
-        ...GroupSet
+        ...StudentGroupSet
       }
       lockAt
       lockInfo {
@@ -91,7 +91,7 @@ export const Assignment = {
 
 export const AssignmentSubmissionsConnection = {
   fragment: gql`
-    fragment AssignmentSubmissionsConnection on Assignment {
+    fragment StudentAssignmentSubmissionsConnection on Assignment {
       submissionsConnection(
         last: 1
         filter: {states: [unsubmitted, graded, pending_review, submitted]}

--- a/ui/shared/assignments/graphql/student/Group.js
+++ b/ui/shared/assignments/graphql/student/Group.js
@@ -21,7 +21,7 @@ import {shape, string} from 'prop-types'
 
 export const Group = {
   fragment: gql`
-    fragment Group on Group {
+    fragment StudentGroup on Group {
       name
       id
       _id

--- a/ui/shared/assignments/graphql/student/GroupSet.js
+++ b/ui/shared/assignments/graphql/student/GroupSet.js
@@ -22,12 +22,12 @@ import {Group} from './Group'
 
 export const GroupSet = {
   fragment: gql`
-    fragment GroupSet on GroupSet {
+    fragment StudentGroupSet on GroupSet {
       name
       id
       _id
       currentGroup {
-        ...Group
+        ...StudentGroup
       }
     }
     ${Group.fragment}

--- a/ui/shared/assignments/graphql/student/Queries.js
+++ b/ui/shared/assignments/graphql/student/Queries.js
@@ -97,7 +97,7 @@ export const COURSE_PROFICIENCY_RATINGS_QUERY = gql`
 export const STUDENT_VIEW_QUERY = gql`
   query GetStudentAssignment($assignmentLid: ID!, $submissionID: ID!) {
     assignment(id: $assignmentLid) {
-      ...Assignment
+      ...StudentAssignment
       rubric {
         ...Rubric
       }
@@ -118,7 +118,7 @@ export const STUDENT_VIEW_QUERY = gql`
 export const STUDENT_VIEW_QUERY_WITH_REVIEWER_SUBMISSION = gql`
   query GetStudentAssignmentWithReviewerSubmission($assignmentLid: ID!, $submissionID: ID!, $reviewerSubmissionID: ID!) {
     assignment(id: $assignmentLid) {
-      ...Assignment
+      ...StudentAssignment
       rubric {
         ...Rubric
       }
@@ -142,7 +142,7 @@ export const STUDENT_VIEW_QUERY_WITH_REVIEWER_SUBMISSION = gql`
 export const LOGGED_OUT_STUDENT_VIEW_QUERY = gql`
   query GetStudentAssignmentLoggedOut($assignmentLid: ID!) {
     assignment(id: $assignmentLid) {
-      ...Assignment
+      ...StudentAssignment
       rubric {
         ...Rubric
       }

--- a/ui/shared/assignments/graphql/student/SubmissionInterface.js
+++ b/ui/shared/assignments/graphql/student/SubmissionInterface.js
@@ -67,7 +67,7 @@ export const SubmissionInterface = {
       unreadCommentCount
       url
       assignedAssessments {
-        ...AssessmentRequest
+        ...StudentAssessmentRequest
       }
     }
     ${MediaObject.fragment}


### PR DESCRIPTION
Rename all generic GraphQL fragment names in ui/shared/assignments/graphql/student/ to use the StudentAssignment prefix. This ensures fragment names are globally unique and allows the GraphQL codegen to process this directory.

## Changes
- Assignment → StudentAssignment
- AssignmentSubmissionsConnection → StudentAssignmentSubmissionsConnection  
- AssessmentRequest → StudentAssessmentRequest
- Group → StudentGroup
- GroupSet → StudentGroupSet

## Updated References
- Fragment definitions renamed in each .js file
- All fragment spreads updated within the same directory
- Updated references in Assignment.js, GroupSet.js, SubmissionInterface.js, and Queries.js

## Testing
- yarn check:ts passes (pre-existing errors unrelated to changes)
- yarn lint passes with no new errors
- Fragment references verified across codebase

**Jira:** CFA-438
**Waiting for CI validation before Gerrit submission**