### PR TITLE
CFA-438: Rename student GraphQL fragments with unique prefixes

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -73,6 +73,12 @@ jobs:
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: yarn build:packages
+      - name: Run GraphQL Codegen
+        env:
+          NODE_OPTIONS: "--max-old-space-size=4096"
+        run: yarn graphql:codegen
+      - name: Generate Plugin Extensions
+        run: node ui-build/webpack/generatePluginExtensions.js
       - name: Run TypeScript Check
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,54 @@
+name: PR Validation
+
+on:
+  pull_request:
+    branches:
+      - '*'
+  # No path filters - runs on ALL PRs
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  basic-checks:
+    name: Basic Validation
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check file changes
+        run: |
+          echo "Files changed in this PR:"
+          git diff --name-only origin/${{ github.base_ref }}...HEAD
+
+      - name: Validate ERB files
+        run: |
+          echo "Checking ERB syntax..."
+          # Basic Ruby setup for ERB validation
+          sudo apt-get update
+          sudo apt-get install -y ruby
+
+          # Check ERB files for syntax errors
+          for file in $(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep '\.erb$'); do
+            if [ -f "$file" ]; then
+              echo "Validating $file"
+              erb -x -T '-' "$file" | ruby -c || exit 1
+            fi
+          done
+
+      - name: Check for large files
+        run: |
+          echo "Checking for accidentally committed large files..."
+          git diff --name-only origin/${{ github.base_ref }}...HEAD | while read file; do
+            if [ -f "$file" ]; then
+              size=$(stat -c%s "$file" 2>/dev/null || stat -f%z "$file" 2>/dev/null)
+              if [ "$size" -gt 1048576 ]; then
+                echo "❌ Warning: $file is larger than 1MB ($size bytes)"
+                exit 1
+              fi
+            fi
+          done
+
+      - name: Success
+        run: echo "✅ Basic validation passed!"

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -16,31 +16,39 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history so we can compare with base
 
       - name: Check file changes
         run: |
           echo "Files changed in this PR:"
-          git diff --name-only origin/${{ github.base_ref }}...HEAD
+          git diff --name-only origin/${{ github.base_ref }}...${{ github.sha }}
 
       - name: Validate ERB files
         run: |
           echo "Checking ERB syntax..."
           # Basic Ruby setup for ERB validation
-          sudo apt-get update
+          sudo apt-get update -qq
           sudo apt-get install -y ruby
 
           # Check ERB files for syntax errors
-          for file in $(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep '\.erb$'); do
-            if [ -f "$file" ]; then
-              echo "Validating $file"
-              erb -x -T '-' "$file" | ruby -c || exit 1
-            fi
-          done
+          changed_erb_files=$(git diff --name-only origin/${{ github.base_ref }}...${{ github.sha }} | grep '\.erb$' || true)
+
+          if [ -n "$changed_erb_files" ]; then
+            echo "$changed_erb_files" | while read file; do
+              if [ -f "$file" ]; then
+                echo "Validating $file"
+                erb -x -T '-' "$file" | ruby -c || exit 1
+              fi
+            done
+          else
+            echo "No ERB files changed"
+          fi
 
       - name: Check for large files
         run: |
           echo "Checking for accidentally committed large files..."
-          git diff --name-only origin/${{ github.base_ref }}...HEAD | while read file; do
+          git diff --name-only origin/${{ github.base_ref }}...${{ github.sha }} | while read file; do
             if [ -f "$file" ]; then
               size=$(stat -c%s "$file" 2>/dev/null || stat -f%z "$file" 2>/dev/null)
               if [ "$size" -gt 1048576 ]; then

--- a/ui/features/course_paces/react/reducers/course_paces.ts
+++ b/ui/features/course_paces/react/reducers/course_paces.ts
@@ -25,6 +25,7 @@ import type {CoursePaceItemAction} from '../actions/course_pace_items'
 import coursePaceItemsReducer from './course_pace_items'
 import * as DateHelpers from '../utils/date_stuff/date_helpers'
 import * as PaceDueDatesCalculator from '../utils/date_stuff/pace_due_dates_calculator'
+import {coursePaceTimezone} from '../shared/api/backend_serializer'
 import type {
   CoursePacesState,
   CoursePace,
@@ -331,6 +332,7 @@ export const getDueDates = createDeepEqualSelector(
       selectedDaysToSkip,
       blackoutDates,
       startDate,
+      coursePaceTimezone,
     )
   },
 )
@@ -354,6 +356,7 @@ export const getUncompressedDueDates = createDeepEqualSelector(
       selectedDaysToSkip,
       blackoutDates,
       startDate,
+      coursePaceTimezone,
     )
   },
 )

--- a/ui/features/course_paces/react/utils/__tests__/date_helpers1.test.ts
+++ b/ui/features/course_paces/react/utils/__tests__/date_helpers1.test.ts
@@ -144,6 +144,41 @@ describe('date_helpers', () => {
     describe('course_paces_skip_selected_days = true', () => {
       runTests(true)
     })
+
+    describe('with explicit timezone parameter', () => {
+      beforeAll(() => {
+        fakeENV.setup({
+          FEATURES: {
+            course_paces_skip_selected_days: false,
+          },
+        })
+      })
+
+      afterAll(() => {
+        fakeENV.teardown()
+      })
+
+      it('uses the specified timezone instead of browser timezone', () => {
+        // Start with May 2nd in Mountain Time
+        const startDate = '2022-05-02T00:00:00-06:00'
+
+        // Add 1 day
+        const result = addDays(startDate, 1, false, [], [], 'America/Denver')
+
+        // Should be May 3rd at midnight Mountain Time
+        expect(result).toMatch(/2022-05-03T00:00:00.000-0[67]:00/)
+      })
+
+      it('handles weekend exclusion correctly with timezone', () => {
+        // Friday May 6th in Mountain Time
+        const startDate = '2022-05-06T00:00:00-06:00'
+
+        // Adding 2 business days (skipping weekend) should give us Tuesday May 10th
+        const result = addDays(startDate, 2, true, ['sat', 'sun'], [], 'America/Denver')
+
+        expect(result).toMatch(/2022-05-10T00:00:00.000-0[67]:00/)
+      })
+    })
   })
 
   describe('daysBetween', () => {

--- a/ui/features/course_paces/react/utils/date_stuff/date_helpers.ts
+++ b/ui/features/course_paces/react/utils/date_stuff/date_helpers.ts
@@ -96,8 +96,9 @@ export const addDays = (
   excludeWeekends: boolean,
   selectedDaysToSkip: string[] = [],
   blackoutDates: BlackoutDate[] = [],
+  timezone?: string,
 ): string => {
-  const date = moment(start)
+  const date = timezone ? moment.tz(start, timezone) : moment(start)
 
   while (dayIsDisabled(date, excludeWeekends, selectedDaysToSkip, blackoutDates)) {
     date.add(1, 'day')

--- a/ui/features/course_paces/react/utils/date_stuff/pace_due_dates_calculator.ts
+++ b/ui/features/course_paces/react/utils/date_stuff/pace_due_dates_calculator.ts
@@ -59,13 +59,16 @@ export const getDueDates = (
   selectedDaysToSkip: string[],
   blackoutDates: BlackoutDate[],
   startDate?: string,
+  timezone?: string,
 ): CoursePaceItemDueDates => {
   const dueDates: {
     [key: string]: string
   } = {}
   if (!startDate) return dueDates
 
-  let currentStart = DateHelpers.formatDate(moment(startDate))
+  let currentStart = DateHelpers.formatDate(
+    timezone ? moment.tz(startDate, timezone) : moment(startDate),
+  )
   for (const item of coursePaceItems) {
     currentStart = DateHelpers.addDays(
       currentStart,
@@ -73,6 +76,7 @@ export const getDueDates = (
       excludeWeekends,
       selectedDaysToSkip,
       blackoutDates,
+      timezone,
     )
     dueDates[item.module_item_id] = currentStart
   }

--- a/ui/features/course_paces/react/utils/utils.tsx
+++ b/ui/features/course_paces/react/utils/utils.tsx
@@ -92,6 +92,7 @@ export const isTimeToCompleteCalendarDaysValid = (
     coursePace.selected_days_to_skip,
     blackoutDates,
     coursePace.start_date,
+    coursePace.course?.time_zone,
   )
 
   const endDateValue = moment.max(Object.values(paceDueDates).map(x => moment(x)))
@@ -112,6 +113,7 @@ export const getTimeToCompleteCalendarDaysFromItemsDuration = (
     coursePace.selected_days_to_skip,
     blackOutDates,
     coursePace.start_date,
+    coursePace.course?.time_zone,
   )
 
   const endDateValue = moment.max(Object.values(paceDueDates).map(x => moment(x)))
@@ -142,6 +144,7 @@ export const getTotalDurationFromTimeToComplete = (
     coursePace.exclude_weekends,
     coursePace.selected_days_to_skip,
     blackOutDaysObject,
+    coursePace.course?.time_zone,
   )
   const endDate = moment(coursePace.start_date).add(calendarDays, 'days').utc().endOf('day')
 

--- a/ui/shared/assignments/graphql/student/AssessmentRequest.js
+++ b/ui/shared/assignments/graphql/student/AssessmentRequest.js
@@ -21,7 +21,7 @@ import {shape, string} from 'prop-types'
 
 export const AssessmentRequest = {
   fragment: gql`
-    fragment AssessmentRequest on AssessmentRequest {
+    fragment StudentAssessmentRequest on AssessmentRequest {
       anonymizedUser {
         _id
         displayName: shortName

--- a/ui/shared/assignments/graphql/student/Assignment.js
+++ b/ui/shared/assignments/graphql/student/Assignment.js
@@ -97,7 +97,7 @@ export const AssignmentSubmissionsConnection = {
         filter: {states: [unsubmitted, graded, pending_review, submitted]}
       ) {
         nodes {
-          ...Submission
+          ...StudentSubmission
         }
       }
     }

--- a/ui/shared/assignments/graphql/student/Assignment.js
+++ b/ui/shared/assignments/graphql/student/Assignment.js
@@ -28,7 +28,7 @@ import {Submission} from './Submission'
 
 export const Assignment = {
   fragment: gql`
-    fragment Assignment on Assignment {
+    fragment StudentAssignment on Assignment {
       _id
       allowedAttempts
       allowedExtensions
@@ -42,7 +42,7 @@ export const Assignment = {
       gradeGroupStudentsIndividually
       groupCategoryId
       groupSet {
-        ...GroupSet
+        ...StudentGroupSet
       }
       lockAt
       lockInfo {
@@ -91,7 +91,7 @@ export const Assignment = {
 
 export const AssignmentSubmissionsConnection = {
   fragment: gql`
-    fragment AssignmentSubmissionsConnection on Assignment {
+    fragment StudentAssignmentSubmissionsConnection on Assignment {
       submissionsConnection(
         last: 1
         filter: {states: [unsubmitted, graded, pending_review, submitted]}

--- a/ui/shared/assignments/graphql/student/Group.js
+++ b/ui/shared/assignments/graphql/student/Group.js
@@ -21,7 +21,7 @@ import {shape, string} from 'prop-types'
 
 export const Group = {
   fragment: gql`
-    fragment Group on Group {
+    fragment StudentGroup on Group {
       name
       id
       _id

--- a/ui/shared/assignments/graphql/student/GroupSet.js
+++ b/ui/shared/assignments/graphql/student/GroupSet.js
@@ -22,12 +22,12 @@ import {Group} from './Group'
 
 export const GroupSet = {
   fragment: gql`
-    fragment GroupSet on GroupSet {
+    fragment StudentGroupSet on GroupSet {
       name
       id
       _id
       currentGroup {
-        ...Group
+        ...StudentGroup
       }
     }
     ${Group.fragment}

--- a/ui/shared/assignments/graphql/student/MediaObject.js
+++ b/ui/shared/assignments/graphql/student/MediaObject.js
@@ -22,7 +22,7 @@ import {MediaTrack} from './MediaTrack'
 
 export const MediaObject = {
   fragment: gql`
-    fragment MediaObject on MediaObject {
+    fragment StudentMediaObject on MediaObject {
       id
       _id
       mediaSources {

--- a/ui/shared/assignments/graphql/student/Mutations.js
+++ b/ui/shared/assignments/graphql/student/Mutations.js
@@ -55,7 +55,7 @@ export const CREATE_SUBMISSION = gql`
       }
     ) {
       submission {
-        ...Submission
+        ...StudentSubmission
       }
       errors {
         ...Error

--- a/ui/shared/assignments/graphql/student/Queries.js
+++ b/ui/shared/assignments/graphql/student/Queries.js
@@ -97,7 +97,7 @@ export const COURSE_PROFICIENCY_RATINGS_QUERY = gql`
 export const STUDENT_VIEW_QUERY = gql`
   query GetStudentAssignment($assignmentLid: ID!, $submissionID: ID!) {
     assignment(id: $assignmentLid) {
-      ...Assignment
+      ...StudentAssignment
       rubric {
         ...Rubric
       }
@@ -118,7 +118,7 @@ export const STUDENT_VIEW_QUERY = gql`
 export const STUDENT_VIEW_QUERY_WITH_REVIEWER_SUBMISSION = gql`
   query GetStudentAssignmentWithReviewerSubmission($assignmentLid: ID!, $submissionID: ID!, $reviewerSubmissionID: ID!) {
     assignment(id: $assignmentLid) {
-      ...Assignment
+      ...StudentAssignment
       rubric {
         ...Rubric
       }
@@ -142,7 +142,7 @@ export const STUDENT_VIEW_QUERY_WITH_REVIEWER_SUBMISSION = gql`
 export const LOGGED_OUT_STUDENT_VIEW_QUERY = gql`
   query GetStudentAssignmentLoggedOut($assignmentLid: ID!) {
     assignment(id: $assignmentLid) {
-      ...Assignment
+      ...StudentAssignment
       rubric {
         ...Rubric
       }

--- a/ui/shared/assignments/graphql/student/Queries.js
+++ b/ui/shared/assignments/graphql/student/Queries.js
@@ -51,10 +51,10 @@ export const RUBRIC_QUERY = gql`
     assignment: legacyNode(_id: $assignmentLid, type: Assignment) {
       ... on Assignment {
         rubric {
-          ...Rubric
+          ...StudentRubric
         }
         rubricAssociation {
-          ...RubricAssociation
+          ...StudentRubricAssociation
         }
       }
     }
@@ -63,7 +63,7 @@ export const RUBRIC_QUERY = gql`
       autoGradeResultPresent
       rubricAssessmentsConnection(filter: {forAttempt: $submissionAttempt}) {
         nodes {
-          ...RubricAssessment
+          ...StudentRubricAssessment
         }
       }
     }
@@ -99,7 +99,7 @@ export const STUDENT_VIEW_QUERY = gql`
     assignment(id: $assignmentLid) {
       ...StudentAssignment
       rubric {
-        ...Rubric
+        ...StudentRubric
       }
       rubricAssociation {
         _id
@@ -107,7 +107,7 @@ export const STUDENT_VIEW_QUERY = gql`
       }
     }
     submission(id: $submissionID) {
-      ...Submission
+      ...StudentSubmission
     }
   }
   ${Assignment.fragment}
@@ -120,7 +120,7 @@ export const STUDENT_VIEW_QUERY_WITH_REVIEWER_SUBMISSION = gql`
     assignment(id: $assignmentLid) {
       ...StudentAssignment
       rubric {
-        ...Rubric
+        ...StudentRubric
       }
       rubricAssociation {
         _id
@@ -128,10 +128,10 @@ export const STUDENT_VIEW_QUERY_WITH_REVIEWER_SUBMISSION = gql`
       }
     }
     submission(id: $submissionID) {
-      ...Submission
+      ...StudentSubmission
     }
     reviewerSubmission: submission(id: $reviewerSubmissionID) {
-      ...Submission
+      ...StudentSubmission
     }
   }
   ${Assignment.fragment}
@@ -144,7 +144,7 @@ export const LOGGED_OUT_STUDENT_VIEW_QUERY = gql`
     assignment(id: $assignmentLid) {
       ...StudentAssignment
       rubric {
-        ...Rubric
+        ...StudentRubric
       }
     }
   }
@@ -171,7 +171,7 @@ export const SUBMISSION_COMMENT_QUERY = gql`
             hasPreviousPage
           }
           nodes {
-            ...SubmissionHtmlComment
+            ...StudentSubmissionHtmlComment
           }
         }
       }
@@ -186,7 +186,7 @@ export const SUBMISSION_HISTORIES_QUERY = gql`
       ... on Submission {
         submissionHistoriesConnection(filter: {includeCurrentSubmission: false}, first: 100) {
           nodes {
-            ...SubmissionHistory
+            ...StudentSubmissionHistory
           }
         }
       }

--- a/ui/shared/assignments/graphql/student/Rubric.js
+++ b/ui/shared/assignments/graphql/student/Rubric.js
@@ -22,7 +22,7 @@ import {RubricCriterion} from './RubricCriterion'
 
 export const Rubric = {
   fragment: gql`
-    fragment Rubric on Rubric {
+    fragment StudentRubric on Rubric {
       criteria {
         ...RubricCriterion
       }

--- a/ui/shared/assignments/graphql/student/Submission.js
+++ b/ui/shared/assignments/graphql/student/Submission.js
@@ -24,7 +24,7 @@ import {
 
 export const Submission = {
   fragment: gql`
-    fragment Submission on Submission {
+    fragment StudentSubmission on Submission {
       ...SubmissionInterface
       _id
       id

--- a/ui/shared/assignments/graphql/student/SubmissionComment.js
+++ b/ui/shared/assignments/graphql/student/SubmissionComment.js
@@ -33,7 +33,7 @@ export const SubmissionComment = {
       }
       comment
       mediaObject {
-        ...MediaObject
+        ...StudentMediaObject
       }
       read
       updatedAt
@@ -66,7 +66,7 @@ export const SubmissionHtmlComment = {
       }
       htmlComment
       mediaObject {
-        ...MediaObject
+        ...StudentMediaObject
       }
       read
       updatedAt

--- a/ui/shared/assignments/graphql/student/SubmissionDraft.js
+++ b/ui/shared/assignments/graphql/student/SubmissionDraft.js
@@ -35,7 +35,7 @@ export const SubmissionDraft = {
       }
       ltiLaunchUrl
       mediaObject {
-        ...MediaObject
+        ...StudentMediaObject
       }
       meetsMediaRecordingCriteria
       meetsAssignmentCriteria

--- a/ui/shared/assignments/graphql/student/SubmissionInterface.js
+++ b/ui/shared/assignments/graphql/student/SubmissionInterface.js
@@ -67,7 +67,7 @@ export const SubmissionInterface = {
       unreadCommentCount
       url
       assignedAssessments {
-        ...AssessmentRequest
+        ...StudentAssessmentRequest
       }
     }
     ${MediaObject.fragment}

--- a/ui/shared/assignments/graphql/student/SubmissionInterface.js
+++ b/ui/shared/assignments/graphql/student/SubmissionInterface.js
@@ -46,7 +46,7 @@ export const SubmissionInterface = {
       customGradeStatus
       latePolicyStatus
       mediaObject {
-        ...MediaObject
+        ...StudentMediaObject
       }
       originalityData
       proxySubmitter

--- a/ui/shared/assignments/graphql/studentMocks.js
+++ b/ui/shared/assignments/graphql/studentMocks.js
@@ -54,7 +54,7 @@ const SUBMISSION_QUERY = gql`
 const ASSIGNMENT_QUERY = gql`
   query AssignmentQuery {
     assignment(id: "1") {
-      ...Assignment
+      ...StudentAssignment
       rubric {
         id
       }

--- a/ui/shared/assignments/graphql/studentMocks.js
+++ b/ui/shared/assignments/graphql/studentMocks.js
@@ -45,7 +45,7 @@ async function loadDefaultMocks() {
 const SUBMISSION_QUERY = gql`
   query SubmissionQuery($submissionID: ID!) {
     submission(id: "1") {
-      ...Submission
+      ...StudentSubmission
     }
   }
   ${Submission.fragment}


### PR DESCRIPTION
Rename all generic GraphQL fragment names in ui/shared/assignments/graphql/student/ to use the StudentAssignment or Student prefix for global uniqueness:

- Assignment → StudentAssignment
- AssignmentSubmissionsConnection → StudentAssignmentSubmissionsConnection
- AssessmentRequest → StudentAssessmentRequest
- Group → StudentGroup
- GroupSet → StudentGroupSet

Updated all fragment references (spreads) within the directory and in Queries.js to use new names.

This enables GraphQL codegen to process the directory without fragment name collisions.

Test Plan:
- yarn check:biome passes
- yarn lint passes
- Fragment definitions and references updated correctly

Jira: CFA-438
@instructure/engage