### PR TITLE
Fix race condition in ActionsMenuCell test

### DIFF
--- a/ui/features/accessibility/accessibility_checker/react/components/AccessibilityIssuesTable/Cells/__tests__/ActionsMenuCell.test.tsx
+++ b/ui/features/accessibility/accessibility_checker/react/components/AccessibilityIssuesTable/Cells/__tests__/ActionsMenuCell.test.tsx
@@ -318,9 +318,12 @@ describe('ActionsMenuCell', () => {
   describe('loading states', () => {
     it('disables menu items while loading and shows screen reader announcement', async () => {
       const user = userEvent.setup()
+      let resolveRequest!: (value: {json: object; response: {ok: boolean}}) => void
       mockDoFetchApi.mockImplementation(
         () =>
-          new Promise(resolve => setTimeout(() => resolve({json: {}, response: {ok: true}}), 100)),
+          new Promise(resolve => {
+            resolveRequest = resolve
+          }),
       )
 
       render(<ActionsMenuCell scan={activeScan} />, {wrapper})
@@ -341,6 +344,9 @@ describe('ActionsMenuCell', () => {
       await user.click(menuButton)
       const menuItem = screen.getByText(/close remediation/i).closest('[role="menuitem"]')
       expect(menuItem).toHaveAttribute('aria-disabled', 'true')
+
+      // Now resolve the request
+      resolveRequest({json: {}, response: {ok: true}})
 
       await waitFor(() => {
         expect(screen.queryByText(/closing remediation, please wait/i)).not.toBeInTheDocument()


### PR DESCRIPTION
## Summary
- Replace `setTimeout`-based mock with manually controlled promise in ActionsMenuCell loading states test
- Prevents timing-dependent flaky failures where 100ms timeout could elapse before assertions complete

fixes CFA-441

## Test plan
- [ ] UI Tests Shard 15 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)