### PR TITLE
Fix timer cleanup ordering in setup-vitests

### DIFF
--- a/ui/setup-vitests.tsx
+++ b/ui/setup-vitests.tsx
@@ -67,6 +67,11 @@ globalThis.clearInterval = ((id?: ReturnType<typeof setInterval>) => {
 // Global cleanup after each test to prevent memory leaks and timer issues
 // This is especially important for InstUI components that use transitions with setTimeout
 afterEach(() => {
+  // Clean up any rendered React components that weren't explicitly unmounted.
+  // This must run BEFORE clearing timers because cleanup() can trigger InstUI
+  // Transition animations that create new timers via setTimeout.
+  cleanup()
+
   // Clear all pending timers from InstUI transitions, animations, etc.
   // These can cause "document is not defined" errors when they fire after jsdom teardown
   for (const id of pendingTimeouts) {
@@ -78,10 +83,6 @@ afterEach(() => {
     originalClearInterval(id)
   }
   pendingIntervals.clear()
-
-  // Clean up any rendered React components that weren't explicitly unmounted
-  // This is a safeguard for tests that don't properly clean up
-  cleanup()
 })
 
 // jQuery plugins (toJSON, dialog, droppable, etc.) are added via the jquery-with-plugins.ts wrapper


### PR DESCRIPTION
## Summary
- Reorder `afterEach` in `setup-vitests.tsx` to call `cleanup()` before clearing timers
- React unmount via `cleanup()` triggers InstUI Transition animations that create new `setTimeout` timers
- Previously, clearing timers first meant these new animation timers fired after jsdom teardown, causing "document is not defined" errors

fixes CFA-442

## Test plan
- [ ] UI Tests Shard 5 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)