### PR TITLE
CFA-437: Rename discussion_topics_post fragments with DiscussionPost prefix

### DIFF
--- a/ui/features/discussion_topics_post/graphql/AssessmentRequest.js
+++ b/ui/features/discussion_topics_post/graphql/AssessmentRequest.js
@@ -21,7 +21,7 @@ import {shape, string} from 'prop-types'
 
 export const AssessmentRequest = {
   fragment: gql`
-    fragment AssessmentRequest on AssessmentRequest {
+    fragment DiscussionPostAssessmentRequest on AssessmentRequest {
       _id
       createdAt
       updatedAt

--- a/ui/features/discussion_topics_post/graphql/Assignment.js
+++ b/ui/features/discussion_topics_post/graphql/Assignment.js
@@ -27,7 +27,7 @@ import {Checkpoint} from './Checkpoint'
 
 export const Assignment = {
   fragment: gql`
-    fragment Assignment on Assignment {
+    fragment DiscussionPostAssignment on Assignment {
       id
       _id
       dueAt(applyOverrides: false)
@@ -38,7 +38,7 @@ export const Assignment = {
       restrictQuantitativeData(checkExtraPermissions: true)
       assignmentOverrides {
         nodes {
-          ...AssignmentOverride
+          ...DiscussionPostAssignmentOverride
         }
       }
       checkpoints {
@@ -50,7 +50,7 @@ export const Assignment = {
         }
       }
       assessmentRequestsForCurrentUser {
-        ...AssessmentRequest
+        ...DiscussionPostAssessmentRequest
       }
       peerReviews {
         ...PeerReviews

--- a/ui/features/discussion_topics_post/graphql/AssignmentOverride.js
+++ b/ui/features/discussion_topics_post/graphql/AssignmentOverride.js
@@ -23,7 +23,7 @@ import {shape, string, oneOfType} from 'prop-types'
 
 export const AssignmentOverride = {
   fragment: gql`
-    fragment AssignmentOverride on AssignmentOverride {
+    fragment DiscussionPostAssignmentOverride on AssignmentOverride {
       id
       _id
       dueAt
@@ -35,7 +35,7 @@ export const AssignmentOverride = {
           ...AdhocStudents
         }
         ... on Group {
-          ...Group
+          ...DiscussionPostGroup
         }
       }
     }

--- a/ui/features/discussion_topics_post/graphql/Attachment.js
+++ b/ui/features/discussion_topics_post/graphql/Attachment.js
@@ -21,7 +21,7 @@ import {shape, string} from 'prop-types'
 
 export const Attachment = {
   fragment: gql`
-    fragment Attachment on File {
+    fragment DiscussionPostAttachment on File {
       id
       _id
       displayName

--- a/ui/features/discussion_topics_post/graphql/Checkpoint.js
+++ b/ui/features/discussion_topics_post/graphql/Checkpoint.js
@@ -30,7 +30,7 @@ export const Checkpoint = {
       onlyVisibleToOverrides
       assignmentOverrides {
         nodes {
-          ...AssignmentOverride
+          ...DiscussionPostAssignmentOverride
         }
       }
     }

--- a/ui/features/discussion_topics_post/graphql/Course.js
+++ b/ui/features/discussion_topics_post/graphql/Course.js
@@ -21,7 +21,7 @@ import {gql} from '@apollo/client'
 
 export const Course = {
   fragment: gql`
-    fragment Course on Course {
+    fragment DiscussionPostCourse on Course {
       _id
       id
       name

--- a/ui/features/discussion_topics_post/graphql/Discussion.js
+++ b/ui/features/discussion_topics_post/graphql/Discussion.js
@@ -64,32 +64,32 @@ export const Discussion = {
       sortOrderLocked
       expandedLocked
       editor {
-        ...User
+        ...DiscussionPostUser
       }
       author {
-        ...User
+        ...DiscussionPostUser
       }
       entryCounts {
         unreadCount
         repliesCount
       }
       attachment {
-        ...Attachment
+        ...DiscussionPostAttachment
       }
       assignment {
-        ...Assignment
+        ...DiscussionPostAssignment
       }
       permissions {
         ...DiscussionPermissions
       }
       courseSections {
-        ...Section
+        ...DiscussionPostSection
       }
       childTopics {
         ...ChildTopic
       }
       groupSet {
-        ...GroupSet
+        ...DiscussionPostGroupSet
       }
       rootTopic {
         ...RootTopic

--- a/ui/features/discussion_topics_post/graphql/DiscussionEntry.js
+++ b/ui/features/discussion_topics_post/graphql/DiscussionEntry.js
@@ -43,13 +43,13 @@ export const DiscussionEntry = {
         shortName
       }
       editor {
-        ...User
+        ...DiscussionPostUser
       }
       author {
-        ...User
+        ...DiscussionPostUser
       }
       attachment {
-        ...Attachment
+        ...DiscussionPostAttachment
       }
       entryParticipant {
         rating

--- a/ui/features/discussion_topics_post/graphql/Group.js
+++ b/ui/features/discussion_topics_post/graphql/Group.js
@@ -21,7 +21,7 @@ import {number, shape, string} from 'prop-types'
 
 export const Group = {
   fragment: gql`
-    fragment Group on Group {
+    fragment DiscussionPostGroup on Group {
       id
       _id
       name

--- a/ui/features/discussion_topics_post/graphql/GroupSet.js
+++ b/ui/features/discussion_topics_post/graphql/GroupSet.js
@@ -22,12 +22,12 @@ import {Group} from './Group'
 
 export const GroupSet = {
   fragment: gql`
-    fragment GroupSet on GroupSet {
+    fragment DiscussionPostGroupSet on GroupSet {
       id
       _id
       name
       currentGroup {
-        ...Group
+        ...DiscussionPostGroup
       }
     }
     ${Group.fragment}

--- a/ui/features/discussion_topics_post/graphql/Mutations.js
+++ b/ui/features/discussion_topics_post/graphql/Mutations.js
@@ -226,7 +226,7 @@ export const UPDATE_SPLIT_SCREEN_VIEW_DEEPLY_NESTED_ALERT = gql`
       input: {splitScreenViewDeeplyNestedAlert: $splitScreenViewDeeplyNestedAlert}
     ) {
       user {
-        ...User
+        ...DiscussionPostUser
       }
     }
   }

--- a/ui/features/discussion_topics_post/graphql/Queries.js
+++ b/ui/features/discussion_topics_post/graphql/Queries.js
@@ -70,9 +70,9 @@ export const DISCUSSION_QUERY = gql`
         )
         searchEntryCount(filter: $filter, searchTerm: $searchTerm)
         groupSet {
-          ...GroupSet
+          ...DiscussionPostGroupSet
           groups {
-            ...Group
+            ...DiscussionPostGroup
           }
         }
         ${ENV.discussion_pin_post ? 'pinnedEntries { ...DiscussionEntry }' : ''}
@@ -203,7 +203,7 @@ export const COURSE_USER_QUERY = gql`
   query GetCourseUserQuery($courseId: ID!) {
     legacyNode(_id: $courseId, type: Course) {
       ... on Course {
-        ...Course
+        ...DiscussionPostCourse
       }
     }
   }

--- a/ui/features/discussion_topics_post/graphql/Section.js
+++ b/ui/features/discussion_topics_post/graphql/Section.js
@@ -21,7 +21,7 @@ import {number, shape, string} from 'prop-types'
 
 export const Section = {
   fragment: gql`
-    fragment Section on Section {
+    fragment DiscussionPostSection on Section {
       _id
       createdAt
       id

--- a/ui/features/discussion_topics_post/graphql/User.js
+++ b/ui/features/discussion_topics_post/graphql/User.js
@@ -21,7 +21,7 @@ import {arrayOf, shape, string} from 'prop-types'
 
 export const User = {
   fragment: gql`
-    fragment User on User {
+    fragment DiscussionPostUser on User {
       id
       _id
       avatarUrl


### PR DESCRIPTION
Rename all generic GraphQL fragment names in ui/features/discussion_topics_post/graphql/ to use the DiscussionPost prefix. This ensures fragment names are globally unique and allows the GraphQL codegen to process this directory.

## Changes
- Assignment → DiscussionPostAssignment
- AssignmentOverride → DiscussionPostAssignmentOverride
- AssessmentRequest → DiscussionPostAssessmentRequest
- Attachment → DiscussionPostAttachment
- Course → DiscussionPostCourse
- Group → DiscussionPostGroup
- GroupSet → DiscussionPostGroupSet
- Section → DiscussionPostSection
- User → DiscussionPostUser

All fragment definitions and references updated.

Resolves CFA-437