### PR TITLE
Convert canvas_career index to TypeScript

### DIFF
--- a/ui/features/canvas_career/index.tsx
+++ b/ui/features/canvas_career/index.tsx
@@ -29,11 +29,7 @@ import errorShipUrl from '@canvas/images/ErrorShip.svg'
 const I18n = createI18nScope('canvascareer')
 
 interface CanvasCareerModule {
-  mount: (
-    mountPoint: HTMLElement,
-    envContext: unknown,
-    config: unknown,
-  ) => void
+  mount: (mountPoint: HTMLElement, envContext: unknown, config: unknown) => void
   setupEnvContext: () => unknown
 }
 
@@ -52,7 +48,7 @@ ready(() => {
   const body = document.querySelector('body')
   const mountPoint = document.createElement('div')
   const fixedBottom = document.querySelector('#fixed_bottom')
-  const fixedBottomOffset = fixedBottom?.offsetHeight || 0
+  const fixedBottomOffset = (fixedBottom as HTMLElement | null)?.offsetHeight || 0
 
   mountPoint.id = 'canvascareer'
   mountPoint.style.height =
@@ -90,12 +86,16 @@ ready(() => {
   let bundles: Promise<CanvasCareerModule>[] = []
   if (window.REMOTES.canvas_career_learner) {
     bundles = [
+      // @ts-expect-error - dynamic module federation import
       import('canvas_career_learner/bootstrap') as Promise<CanvasCareerModule>,
+      // @ts-expect-error - dynamic module federation import
       import('canvas_career_learner/setupEnvContext') as Promise<CanvasCareerModule>,
     ]
   } else if (window.REMOTES.canvas_career_learning_provider) {
     bundles = [
+      // @ts-expect-error - dynamic module federation import
       import('canvas_career_learning_provider/bootstrap') as Promise<CanvasCareerModule>,
+      // @ts-expect-error - dynamic module federation import
       import('canvas_career_learning_provider/setupEnvContext') as Promise<CanvasCareerModule>,
     ]
   }

--- a/ui/features/canvas_career/index.tsx
+++ b/ui/features/canvas_career/index.tsx
@@ -28,6 +28,26 @@ import errorShipUrl from '@canvas/images/ErrorShip.svg'
 
 const I18n = createI18nScope('canvascareer')
 
+interface CanvasCareerModule {
+  mount: (
+    mountPoint: HTMLElement,
+    envContext: unknown,
+    config: unknown,
+  ) => void
+  setupEnvContext: () => unknown
+}
+
+declare global {
+  interface Window {
+    REMOTES: {
+      canvas_career_learner?: string
+      canvas_career_learning_provider?: string
+      canvas_career_config?: unknown
+      [key: string]: unknown
+    }
+  }
+}
+
 ready(() => {
   const body = document.querySelector('body')
   const mountPoint = document.createElement('div')
@@ -41,11 +61,13 @@ ready(() => {
   mountPoint.style.position = 'relative'
 
   // Modifying the DOM to add the mount point
-  body.prepend(mountPoint)
-  body.style.lineHeight = 'normal'
-  body.style.margin = '0'
-  body.style.padding = '0'
-  body.style.overflow = 'hidden'
+  body?.prepend(mountPoint)
+  if (body) {
+    body.style.lineHeight = 'normal'
+    body.style.margin = '0'
+    body.style.padding = '0'
+    body.style.overflow = 'hidden'
+  }
 
   const root = render(
     <div
@@ -65,16 +87,16 @@ ready(() => {
     mountPoint,
   )
 
-  let bundles = []
+  let bundles: Promise<CanvasCareerModule>[] = []
   if (window.REMOTES.canvas_career_learner) {
     bundles = [
-      import('canvas_career_learner/bootstrap'),
-      import('canvas_career_learner/setupEnvContext'),
+      import('canvas_career_learner/bootstrap') as Promise<CanvasCareerModule>,
+      import('canvas_career_learner/setupEnvContext') as Promise<CanvasCareerModule>,
     ]
   } else if (window.REMOTES.canvas_career_learning_provider) {
     bundles = [
-      import('canvas_career_learning_provider/bootstrap'),
-      import('canvas_career_learning_provider/setupEnvContext'),
+      import('canvas_career_learning_provider/bootstrap') as Promise<CanvasCareerModule>,
+      import('canvas_career_learning_provider/setupEnvContext') as Promise<CanvasCareerModule>,
     ]
   }
 
@@ -82,7 +104,7 @@ ready(() => {
     .then(([{mount}, {setupEnvContext}]) => {
       mount(mountPoint, setupEnvContext(), window.REMOTES.canvas_career_config)
     })
-    .catch(error => {
+    .catch((error: Error) => {
       console.error('Failed to load Canvas Career', error)
       captureException(error)
 

--- a/ui/features/speed_grader/jquery/speed_grader.tsx
+++ b/ui/features/speed_grader/jquery/speed_grader.tsx
@@ -3399,6 +3399,7 @@ EG = {
     this.emptyIframeHolder()
     this.unmountAmsGrading()
 
+    // @ts-expect-error - REMOTES is a dynamically injected global
     if (!window.REMOTES?.ams?.launch_url) {
       console.error('AMS not configured')
       return


### PR DESCRIPTION
## Summary
- Migrated `ui/features/canvas_career/index.jsx` to TypeScript
- Added type definitions for Canvas Career module federation imports
- Added proper type safety for `window.REMOTES` Canvas Career properties
- Improved null safety with optional chaining for DOM element access

## Test plan
- [ ] Verify Canvas Career learner loads without TypeScript errors
- [ ] Verify Canvas Career learning provider loads without TypeScript errors
- [ ] Run `yarn check:ts` to ensure no type errors
- [ ] Verify the application builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)