### PR TITLE
Convert course settings helpers to TypeScript

### DIFF
--- a/ui/features/course_settings/react/__tests__/helpers.spec.ts
+++ b/ui/features/course_settings/react/__tests__/helpers.spec.ts
@@ -68,6 +68,7 @@ describe('Course Settings Helpers', () => {
       },
     }
 
+    // @ts-expect-error - using simplified mock events for testing
     const changeResults = Helpers.extractInfoFromEvent(changeEvent as ExtractableEvent)
     const expectedChangeResults = {
       file: {
@@ -76,6 +77,7 @@ describe('Course Settings Helpers', () => {
       type: 'image/jpeg',
     }
 
+    // @ts-expect-error - using simplified mock events for testing
     const dragResults = Helpers.extractInfoFromEvent(dragEvent as ExtractableEvent)
     const expectedDragResults = {
       file: {

--- a/ui/features/course_settings/react/helpers.ts
+++ b/ui/features/course_settings/react/helpers.ts
@@ -17,7 +17,7 @@
  */
 
 const Helpers = {
-  isValidImageType(mimeType) {
+  isValidImageType(mimeType: string): boolean {
     return [
       'image/apng',
       'image/avif',
@@ -30,15 +30,20 @@ const Helpers = {
     ].includes(mimeType)
   },
 
-  extractInfoFromEvent(event) {
-    let file = ''
-    let type = ''
+  extractInfoFromEvent(event: React.ChangeEvent<HTMLInputElement> | React.DragEvent): {
+    file: File
+    type: string
+  } {
+    let file: File
+    let type: string
     if (event.type === 'change') {
-      file = event.target.files[0]
+      const changeEvent = event as React.ChangeEvent<HTMLInputElement>
+      file = changeEvent.target.files![0]
       type = file.type
     } else {
-      type = event.dataTransfer.files[0].type
-      file = event.dataTransfer.files[0]
+      const dragEvent = event as React.DragEvent
+      type = dragEvent.dataTransfer.files[0].type
+      file = dragEvent.dataTransfer.files[0]
     }
 
     return {file, type}


### PR DESCRIPTION
## Summary
- Converted `ui/features/course_settings/react/helpers.js` to TypeScript
- Added type annotations for image validation helpers
- Improved type safety for event handling in file operations

## Test plan
- Run TypeScript compiler to verify type correctness
- Verify existing tests still pass
- Check that imports resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)