### PR TITLE
Migrate choose-mastery-path component to TypeScript

### DIFF
--- a/ui/features/choose_mastery_path/react/components/choose-mastery-path.tsx
+++ b/ui/features/choose_mastery_path/react/components/choose-mastery-path.tsx
@@ -17,22 +17,24 @@
  */
 
 import React from 'react'
-import PropTypes from 'prop-types'
 import {useScope as createI18nScope} from '@canvas/i18n'
 import PathOption from './path-option'
-import optionShape from '../shapes/option-shape'
+import type {Assignment} from '../shapes/assignment-shape'
 
 const I18n = createI18nScope('choose_mastery_path')
 
-const {func, number, arrayOf} = PropTypes
+export interface Option {
+  setId: number
+  assignments: Assignment[]
+}
 
-export default class ChooseMasteryPath extends React.Component {
-  static propTypes = {
-    options: arrayOf(optionShape).isRequired,
-    selectedOption: number,
-    selectOption: func.isRequired,
-  }
+interface Props {
+  options: Option[]
+  selectedOption?: number | null
+  selectOption: (setId: number) => void
+}
 
+export default class ChooseMasteryPath extends React.Component<Props> {
   renderHeader() {
     const selectedOption = this.props.selectedOption
     if (selectedOption !== null && selectedOption !== undefined) {

--- a/ui/features/choose_mastery_path/react/shapes/assignment-shape.ts
+++ b/ui/features/choose_mastery_path/react/shapes/assignment-shape.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2016 - present Instructure, Inc.
+ *
+ * This file is part of Canvas.
+ *
+ * Canvas is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type {Category} from './category-shape'
+
+export interface Assignment {
+  name: string
+  description?: string
+  points_possible?: number
+  due_at?: Date
+  category: Category
+}

--- a/ui/features/choose_mastery_path/react/shapes/category-shape.ts
+++ b/ui/features/choose_mastery_path/react/shapes/category-shape.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2016 - present Instructure, Inc.
+ *
+ * This file is part of Canvas.
+ *
+ * Canvas is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export interface Category {
+  id: string
+  label: string
+}


### PR DESCRIPTION
## Summary
- Migrates the ChooseMasteryPath React component from JSX to TypeScript
- Creates TypeScript type definitions for Assignment and Category shapes
- Adds proper type safety with interface definitions for props

## Test plan
- Verify TypeScript compilation passes
- Ensure existing functionality remains unchanged
- Run existing tests to confirm no regressions

Generated with [Claude Code](https://claude.com/claude-code)