### PR TITLE
TypeScriptify content_migrations

### DIFF
--- a/ui/features/content_migrations/backbone/views/MigrationConverterView.tsx
+++ b/ui/features/content_migrations/backbone/views/MigrationConverterView.tsx
@@ -34,18 +34,21 @@ extend(MigrationConverterView, ValidatedFormView)
 
 // This is an abstract class that is inherited
 // from by other MigrationConverter views
-function MigrationConverterView() {
+function MigrationConverterView(this: any) {
   this.exitUploadingState = this.exitUploadingState.bind(this)
   this.enterUploadingState = this.enterUploadingState.bind(this)
   this.resetForm = this.resetForm.bind(this)
+  // @ts-expect-error
   return MigrationConverterView.__super__.constructor.apply(this, arguments)
 }
 
 MigrationConverterView.optionProperty('selectOptions')
 
+// @ts-expect-error
 MigrationConverterView.prototype.template = template
 
-MigrationConverterView.prototype.initialize = function () {
+MigrationConverterView.prototype.initialize = function (this: any) {
+  // @ts-expect-error
   MigrationConverterView.__super__.initialize.apply(this, arguments)
   return $.subscribe('resetForm', this.resetForm)
 }
@@ -67,7 +70,8 @@ MigrationConverterView.prototype.events = lodashExtend(
   },
 )
 
-MigrationConverterView.prototype.toJSON = function (json) {
+MigrationConverterView.prototype.toJSON = function (this: any, json: any) {
+  // @ts-expect-error
   json = MigrationConverterView.__super__.toJSON.apply(this, arguments)
   json.selectOptions = this.selectOptions || ENV.SELECT_OPTIONS
   return json
@@ -78,10 +82,10 @@ MigrationConverterView.prototype.toJSON = function (json) {
 // converter div if there were any previous
 // items set.
 
-MigrationConverterView.prototype.renderConverter = function (converter) {
+MigrationConverterView.prototype.renderConverter = function (this: any, converter: any) {
   if (converter) {
     return defer(
-      (function (_this) {
+      (function (_this: any) {
         return function () {
           _this.$converter.html(converter.render().$el)
           return _this.trigger('converterRendered')
@@ -100,7 +104,7 @@ MigrationConverterView.prototype.renderConverter = function (converter) {
 // it's migration_type to the view being shown.
 //
 // @api private
-MigrationConverterView.prototype.selectConverter = function (_event) {
+MigrationConverterView.prototype.selectConverter = function (this: any, _event: any) {
   this.$formActions.show()
   this.model.resetModel()
   this.$chooseMigrationConverter.attr('aria-activedescendant', this.$chooseMigrationConverter.val())
@@ -118,19 +122,20 @@ MigrationConverterView.prototype.selectConverter = function (_event) {
 //
 // @expects event
 // @api ValidatedFormView override
-MigrationConverterView.prototype.submit = function (_event) {
+MigrationConverterView.prototype.submit = function (this: any, _event: any) {
   this.enterUploadingState()
+  // @ts-expect-error
   const dfd = MigrationConverterView.__super__.submit.apply(this, arguments)
   if (dfd && typeof dfd === 'object') {
     dfd.always(
-      (function (_this) {
+      (function (_this: any) {
         return function () {
           return _this.exitUploadingState()
         }
       })(this),
     )
     return dfd.done(
-      (function (_this) {
+      (function (_this: any) {
         return function () {
           $.publish('migrationCreated', _this.model.attributes)
           _this.model.resetModel()
@@ -148,7 +153,7 @@ MigrationConverterView.prototype.submit = function (_event) {
 // when switching dropdowns so should be fine.
 //
 // @api private
-MigrationConverterView.prototype.resetForm = function () {
+MigrationConverterView.prototype.resetForm = function (this: any) {
   this.$formActions.hide()
   this.$converter.empty()
   return this.$chooseMigrationConverter.val('none')
@@ -158,7 +163,7 @@ MigrationConverterView.prototype.resetForm = function () {
 // enables the warning about navigating away from the page
 //
 // @api private
-MigrationConverterView.prototype.enterUploadingState = function () {
+MigrationConverterView.prototype.enterUploadingState = function (this: any) {
   this.btnText = this.$submitBtn.val()
   this.$submitBtn.val(I18n.t('uploading', 'Uploading...'))
   $(window).on('beforeunload', function () {
@@ -181,23 +186,22 @@ MigrationConverterView.prototype.enterUploadingState = function () {
 // (otherwise, a 100% bar will briefly appear when a second content migration is started)
 //
 // @api private
-MigrationConverterView.prototype.exitUploadingState = function () {
+MigrationConverterView.prototype.exitUploadingState = function (this: any) {
   $(window).off('beforeunload')
   $('#migration_upload_progress_container').hide()
-  ReactDOM.unmountComponentAtNode(document.getElementById('migration_upload_progress_bar'))
+  ReactDOM.unmountComponentAtNode(document.getElementById('migration_upload_progress_bar')!)
   return this.$submitBtn.val(this.btnText)
 }
 
-MigrationConverterView.prototype.afterRender = function () {
-  // eslint-disable-next-line react/no-children-prop
-  const alert = React.createElement(Alert, {
-    children: I18n.t(
-      'Previously imported content from the same course will be replaced. Manually added content will remain.',
-    ),
-    variant: 'warning',
-    hasShadow: false,
-    margin: '0 0 medium 0',
-  })
+MigrationConverterView.prototype.afterRender = function (this: any) {
+  const alert = (
+    // @ts-expect-error
+    <Alert variant="warning" hasShadow={false} margin="0 0 medium 0">
+      {I18n.t(
+        'Previously imported content from the same course will be replaced. Manually added content will remain.',
+      )}
+    </Alert>
+  )
   if (this.$overwriteWarning[0]) {
     // eslint-disable-next-line react/no-render-return-value
     return ReactDOM.render(alert, this.$overwriteWarning[0])

--- a/ui/features/content_migrations/backbone/views/MigrationConverterView.tsx
+++ b/ui/features/content_migrations/backbone/views/MigrationConverterView.tsx
@@ -30,10 +30,12 @@ import ReactDOM from 'react-dom'
 
 const I18n = createI18nScope('content_migrations')
 
+// @ts-expect-error
 extend(MigrationConverterView, ValidatedFormView)
 
 // This is an abstract class that is inherited
 // from by other MigrationConverter views
+// @ts-expect-error
 function MigrationConverterView(this: any) {
   this.exitUploadingState = this.exitUploadingState.bind(this)
   this.enterUploadingState = this.enterUploadingState.bind(this)
@@ -42,9 +44,9 @@ function MigrationConverterView(this: any) {
   return MigrationConverterView.__super__.constructor.apply(this, arguments)
 }
 
+// @ts-expect-error
 MigrationConverterView.optionProperty('selectOptions')
 
-// @ts-expect-error
 MigrationConverterView.prototype.template = template
 
 MigrationConverterView.prototype.initialize = function (this: any) {
@@ -73,6 +75,7 @@ MigrationConverterView.prototype.events = lodashExtend(
 MigrationConverterView.prototype.toJSON = function (this: any, json: any) {
   // @ts-expect-error
   json = MigrationConverterView.__super__.toJSON.apply(this, arguments)
+  // @ts-expect-error
   json.selectOptions = this.selectOptions || ENV.SELECT_OPTIONS
   return json
 }
@@ -109,6 +112,7 @@ MigrationConverterView.prototype.selectConverter = function (this: any, _event: 
   this.model.resetModel()
   this.$chooseMigrationConverter.attr('aria-activedescendant', this.$chooseMigrationConverter.val())
   this.model.set('migration_type', this.$chooseMigrationConverter.val())
+  // @ts-expect-error
   return $.publish('contentImportChange', {
     value: this.$chooseMigrationConverter.val(),
     migrationConverter: this,
@@ -137,6 +141,7 @@ MigrationConverterView.prototype.submit = function (this: any, _event: any) {
     return dfd.done(
       (function (_this: any) {
         return function () {
+          // @ts-expect-error
           $.publish('migrationCreated', _this.model.attributes)
           _this.model.resetModel()
           return _this.resetForm()
@@ -195,7 +200,6 @@ MigrationConverterView.prototype.exitUploadingState = function (this: any) {
 
 MigrationConverterView.prototype.afterRender = function (this: any) {
   const alert = (
-    // @ts-expect-error
     <Alert variant="warning" hasShadow={false} margin="0 0 medium 0">
       {I18n.t(
         'Previously imported content from the same course will be replaced. Manually added content will remain.',

--- a/ui/features/content_migrations/backbone/views/subviews/CourseFindSelectView.ts
+++ b/ui/features/content_migrations/backbone/views/subviews/CourseFindSelectView.ts
@@ -55,11 +55,12 @@ interface CourseFindSelectViewOptions extends Backbone.ViewOptions<Backbone.Mode
   show_select?: boolean
 }
 
+// @ts-expect-error
 extend(CourseFindSelectView, Backbone.View)
 
+// @ts-expect-error
 CourseFindSelectView.optionProperty('current_user_id', 'show_select')
 
-// @ts-expect-error
 CourseFindSelectView.prototype.template = template
 
 function CourseFindSelectView(this: any) {
@@ -129,15 +130,19 @@ CourseFindSelectView.prototype.afterRender = function (this: any) {
   // by the screen reader every time a user selects an auto completed item.
   const $converterDiv = $('#converter')
   this.$courseSearchField.on('focus', function () {
+    // @ts-expect-error
     return $converterDiv.attr('aria-atomic', false)
   })
   this.$courseSearchField.on('blur', function () {
+    // @ts-expect-error
     return $converterDiv.attr('aria-atomic', true)
   })
   this.$courseSelect.on('focus', function () {
+    // @ts-expect-error
     return $converterDiv.attr('aria-atomic', false)
   })
   return this.$courseSelect.on('blur', function () {
+    // @ts-expect-error
     return $converterDiv.attr('aria-atomic', true)
   })
 }
@@ -175,6 +180,7 @@ CourseFindSelectView.prototype.toggleConcludedCourses = function (this: any) {
 // refining the search term
 CourseFindSelectView.prototype.manageableCourseUrl = function (this: any) {
   const params: Record<string, string> = {
+    // @ts-expect-error
     current_course_id: ENV.COURSE_ID,
   }
   if (this.includeConcludedCourses) {

--- a/ui/features/content_migrations/index.ts
+++ b/ui/features/content_migrations/index.ts
@@ -22,9 +22,9 @@ ready(() => {
   // Eventually when the feature flag is retired
   // we can divorce from these shenanigans
   if (document.getElementById('instui_content_migrations')) {
-    import('./instui_setup')
+    void import('./instui_setup')
   } else {
-    import('./setup')
+    void import('./setup')
   }
 })
 


### PR DESCRIPTION
## Summary

Convert JavaScript/JSX files in `ui/features/content_migrations` that import from `@instructure` packages to TypeScript.

### Files Converted

- `index.js` → `index.ts`
- `backbone/views/MigrationConverterView.jsx` → `MigrationConverterView.tsx`
- `backbone/views/subviews/CourseFindSelectView.js` → `CourseFindSelectView.ts`

### Changes Made

- Renamed files to TypeScript extensions (.ts/.tsx)
- Added type annotations for function parameters and return types
- Used `@ts-expect-error` for complex Backbone inheritance and InstUI props
- Added interfaces for data structures (Course, CoursesByTerm, AutocompleteItem)
- Added `this: any` type annotations for Backbone methods
- Converted React.createElement to JSX syntax in MigrationConverterView
- Added void operator for dynamic imports in index.ts

### Type Safety Approach

Following Canvas conventions, this PR uses `@ts-expect-error` for:
- Backbone prototype chain access (`__super__`)
- InstUI component props (complex prop types)
- Handlebars template assignments

This maintains the existing functionality while gradually introducing type safety.

## Test Plan

- [ ] CI checks pass (TypeScript, lint, Biome)
- [ ] Content migrations feature still works as expected
- [ ] No runtime errors in browser console

🤖 Generated with Claude Code