### PR TITLE
TypeScriptify context_prior_users

### DIFF
--- a/ui/features/context_prior_users/index.tsx
+++ b/ui/features/context_prior_users/index.tsx
@@ -18,12 +18,19 @@
 
 import ready from '@instructure/ready'
 import {initializeTopNavPortalWithDefaults} from '@canvas/top-navigation/react/TopNavPortalWithDefaults'
+import type {Crumb} from '@canvas/top-navigation/react/TopNavPortalBase'
 import {useScope as createI18nScope} from '@canvas/i18n'
 
 const I18n = createI18nScope('PriorUsers')
 
 ready(() => {
-  const handleBreadCrumbSetter = ({getCrumbs, setCrumbs}) => {
+  const handleBreadCrumbSetter = ({
+    getCrumbs,
+    setCrumbs,
+  }: {
+    getCrumbs: () => Crumb[]
+    setCrumbs: (crumbs: Crumb[]) => void
+  }): void => {
     const crumbs = getCrumbs()
     crumbs.push({name: I18n.t('People'), url: document.referrer})
     crumbs.push({name: I18n.t('Prior users'), url: ''})


### PR DESCRIPTION
## Summary

Convert `ui/features/context_prior_users/index.jsx` to TypeScript:
- Renamed `index.jsx` to `index.tsx`
- Added proper TypeScript types for breadcrumb handling
- Imported `Crumb` type from `@canvas/top-navigation/react/TopNavPortalBase`
- Added type annotations for `getCrumbs` and `setCrumbs` parameters
- All `@instructure` imports now have proper types

## Test plan

- [ ] Verify TypeScript compilation passes (`yarn check:ts`)
- [ ] Verify linting passes (`yarn lint`)
- [ ] Verify the prior users page loads correctly
- [ ] Verify breadcrumbs display properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)