### PR TITLE
TypeScriptify discussion_topic_insights

### DIFF
--- a/ui/features/discussion_topic_insights/index.tsx
+++ b/ui/features/discussion_topic_insights/index.tsx
@@ -26,5 +26,7 @@ ready(() => {
   mountNutritionFacts('discussioninsights')
   document.querySelector('body')?.classList.add('full-width')
   const contentElement = document.getElementById('discussion-insights-container')
-  render(<DiscussionInsightsApp />, contentElement)
+  if (contentElement) {
+    render(<DiscussionInsightsApp />, contentElement)
+  }
 })

--- a/ui/features/discussion_topic_insights/react/index.tsx
+++ b/ui/features/discussion_topic_insights/react/index.tsx
@@ -25,11 +25,13 @@ import GenericErrorPage from '@canvas/generic-error-page'
 import errorShipUrl from '@canvas/images/ErrorShip.svg'
 import {useScope as createI18nScope} from '@canvas/i18n'
 import LoadingIndicator from '@canvas/loading-indicator/react'
+import type {ApolloClient} from '@apollo/client'
+import type {InMemoryCache} from '@apollo/client'
 
 const I18n = createI18nScope('discussion_insights')
 
 const DiscussionInsightsApp = () => {
-  const [client, setClient] = useState(null)
+  const [client, setClient] = useState<ApolloClient<InMemoryCache> | null>(null)
 
   const queryClient = new QueryClient()
 
@@ -37,7 +39,7 @@ const DiscussionInsightsApp = () => {
     if (!client) {
       setClient(createClient())
     }
-  }, [client, setClient])
+  }, [client])
 
   if (!client) {
     return <LoadingIndicator />


### PR DESCRIPTION
## Summary
- Converted `ui/features/discussion_topic_insights/index.jsx` to TypeScript
- Converted `ui/features/discussion_topic_insights/react/index.jsx` to TypeScript
- Added proper Apollo Client types with `ApolloClient<InMemoryCache>`
- Added null check for `contentElement` before rendering
- Removed `setClient` from useEffect dependencies to avoid unnecessary re-renders

## Changes
- `index.jsx` → `index.tsx`: Added null check before calling render()
- `react/index.jsx` → `react/index.tsx`: Added proper TypeScript types for Apollo Client state and removed setClient from useEffect deps

## Test Plan
- TypeScript compilation passes
- All existing functionality maintained
- Waiting for GitHub Actions CI checks to validate

🤖 Generated with Claude Code