### PR TITLE
TypeScriptify external_content_cancel

### DIFF
--- a/ui/features/external_content_cancel/index.ts
+++ b/ui/features/external_content_cancel/index.ts
@@ -23,7 +23,7 @@ import ready from '@instructure/ready'
 const I18n = createI18nScope('external_content.cancel')
 
 ready(() => {
-  const parentWindow = window.opener || window.parent
+  const parentWindow: WindowProxy = window.opener || window.parent
   postMessageExternalContentCancel(parentWindow)
   setTimeout(
     () =>


### PR DESCRIPTION
## Summary
- Converted `ui/features/external_content_cancel/index.js` to TypeScript
- Added proper `WindowProxy` type annotation for `parentWindow` variable
- File imports `@instructure/ready` package

## Test plan
- [ ] Verify TypeScript compilation passes
- [ ] Verify linting passes
- [ ] Verify biome checks pass
- [ ] Test external content cancellation flow works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)