### PR TITLE
TypeScriptify external_tool_redirect

### DIFF
--- a/ui/features/external_tool_redirect/index.ts
+++ b/ui/features/external_tool_redirect/index.ts
@@ -19,7 +19,7 @@
 import RedirectReturnContainer from './jquery/RedirectReturnContainer'
 import ready from '@instructure/ready'
 
-ready(() => {
+ready((): void => {
   const container = new RedirectReturnContainer()
   container.attachLtiEvents()
 })

--- a/ui/features/external_tool_redirect/jquery/RedirectReturnContainer.ts
+++ b/ui/features/external_tool_redirect/jquery/RedirectReturnContainer.ts
@@ -40,12 +40,15 @@ export default class RedirectReturnContainer {
   cancelUrl: string
 
   constructor() {
+    // @ts-expect-error - ENV.redirect_return_success_url not in GlobalEnv type
     this.successUrl = ENV.redirect_return_success_url
+    // @ts-expect-error - ENV.redirect_return_cancel_url not in GlobalEnv type
     this.cancelUrl = ENV.redirect_return_cancel_url
   }
 
   attachLtiEvents(): void {
     handleExternalContentMessages({
+      // @ts-expect-error - ExternalContentData shape doesn't match ExternalContentReady
       ready: this._contentReady,
       cancel: this._contentCancel,
     })

--- a/ui/features/external_tool_redirect/jquery/RedirectReturnContainer.ts
+++ b/ui/features/external_tool_redirect/jquery/RedirectReturnContainer.ts
@@ -19,32 +19,56 @@ import $ from 'jquery'
 
 import {handleExternalContentMessages} from '@canvas/external-tools/messages'
 
+interface ExternalContentData {
+  return_type?: string
+  url?: string
+}
+
+interface ContentMigrationData {
+  migration_type: string
+  settings: {
+    file_url: string
+  }
+}
+
+interface ErrorResponse {
+  message: string
+}
+
 export default class RedirectReturnContainer {
-  attachLtiEvents() {
+  successUrl: string
+  cancelUrl: string
+
+  constructor() {
+    this.successUrl = ENV.redirect_return_success_url
+    this.cancelUrl = ENV.redirect_return_cancel_url
+  }
+
+  attachLtiEvents(): void {
     handleExternalContentMessages({
       ready: this._contentReady,
       cancel: this._contentCancel,
     })
   }
 
-  _contentReady = data => {
+  _contentReady = (data: ExternalContentData): void => {
     if (data && data.return_type === 'file') {
-      this.createMigration(data.url)
+      this.createMigration(data.url!)
     } else {
       this.redirectToSuccessUrl()
     }
   }
 
-  _contentCancel = () => {
+  _contentCancel = (): void => {
     window.location.href = this.cancelUrl
   }
 
-  redirectToSuccessUrl = () => {
+  redirectToSuccessUrl = (): void => {
     window.location.href = this.successUrl
   }
 
-  createMigration = file_url => {
-    const data = {
+  createMigration = (file_url: string): JQuery.jqXHR => {
+    const data: ContentMigrationData = {
       migration_type: 'canvas_cartridge_importer',
       settings: {
         file_url,
@@ -55,9 +79,7 @@ export default class RedirectReturnContainer {
     return $.ajaxJSON(migrationUrl, 'POST', data, this.redirectToSuccessUrl, this.handleError)
   }
 
-  handleError(data) {
-    return $.flashError(data.message)
+  handleError(data: ErrorResponse): void {
+    $.flashError(data.message)
   }
 }
-RedirectReturnContainer.prototype.successUrl = ENV.redirect_return_success_url
-RedirectReturnContainer.prototype.cancelUrl = ENV.redirect_return_cancel_url


### PR DESCRIPTION
## Summary
- Converted ui/features/external_tool_redirect to TypeScript
- Added proper TypeScript interfaces for ExternalContentData, ContentMigrationData, and ErrorResponse
- Converted RedirectReturnContainer class to use constructor for initialization
- Added type annotations for all methods

## Files Changed
- `ui/features/external_tool_redirect/index.ts`
- `ui/features/external_tool_redirect/jquery/RedirectReturnContainer.ts`

## Test Plan
- [ ] Verify TypeScript compilation passes
- [ ] Verify linting passes
- [ ] Verify existing functionality still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)