### PR TITLE
TypeScriptify external_tools_show

### DIFF
--- a/ui/features/external_tools_show/index.js
+++ b/ui/features/external_tools_show/index.js
@@ -15,5 +15,5 @@
 // You should have received a copy of the GNU Affero General Public License along
 // with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import './jquery/tool_inline'
+import './jquery/tool_inline.ts'
 import './react'

--- a/ui/features/external_tools_show/jquery/tool_inline.ts
+++ b/ui/features/external_tools_show/jquery/tool_inline.ts
@@ -24,6 +24,20 @@ import ToolLaunchResizer from '@canvas/lti/jquery/tool_launch_resizer'
 import ready from '@instructure/ready'
 import MutexManager from '@canvas/mutex-manager/MutexManager'
 
+type ENVType = {
+  LTI_FORM_SUBMIT_DELAY?: number
+  INIT_DRAWER_LAYOUT_MUTEX?: string
+  LTI_TOOL_FORM_ID?: string
+  LTI?: {
+    SEQUENCE?: {
+      ASSET_ID: string
+      COURSE_ID: string
+    }
+  }
+}
+
+declare const ENV: ENVType
+
 ready(() => {
   const formSubmissionDelay = window.ENV.LTI_FORM_SUBMIT_DELAY
   const formSubmissionMutex = window.ENV.INIT_DRAWER_LAYOUT_MUTEX
@@ -36,7 +50,7 @@ ready(() => {
   }
   const $toolForm = $(toolFormId)
 
-  const submitForm = function (submitFn) {
+  const submitForm = function (submitFn?: () => void) {
     if (formSubmissionDelay) {
       setTimeout(() => {
         MutexManager.awaitMutex(formSubmissionMutex, () => {
@@ -114,7 +128,8 @@ ready(() => {
 
   // Iframe resize handler
   const $tool_content_wrapper = $('.tool_content_wrapper')
-  let tool_height, canvas_chrome_height
+  let tool_height: number | undefined
+  let canvas_chrome_height: number | undefined
 
   const $window = $(window)
   const toolResizer = new ToolLaunchResizer(tool_height)
@@ -123,7 +138,7 @@ ready(() => {
 
   if (!is_full_screen) {
     const footerHeight = $('#footer').outerHeight(true) || 0
-    canvas_chrome_height = $tool_content_wrapper.offset().top + footerHeight
+    canvas_chrome_height = $tool_content_wrapper.offset()!.top + footerHeight
   }
 
   if ($tool_content_wrapper.length) {
@@ -148,7 +163,7 @@ ready(() => {
             // module item navigation from PLAT-1687
             const sequenceFooterHeight = $('#sequence_footer').outerHeight(true) || 0
             toolResizer.resize_tool_content_wrapper(
-              $window.height() - canvas_chrome_height - sequenceFooterHeight,
+              $window.height()! - canvas_chrome_height! - sequenceFooterHeight,
             )
           }
         }
@@ -157,6 +172,7 @@ ready(() => {
   }
 
   if (ENV.LTI != null && ENV.LTI.SEQUENCE != null) {
+    // @ts-expect-error - jQuery plugin types are not available
     $('#module_sequence_footer').moduleSequenceFooter({
       assetType: 'Lti',
       assetID: ENV.LTI.SEQUENCE.ASSET_ID,


### PR DESCRIPTION
## Summary

Convert `ui/features/external_tools_show` JavaScript files to TypeScript:

- Converted `jquery/tool_inline.js` to TypeScript with proper type definitions
- Added `ENVType` interface for window.ENV properties
- Typed function parameters and variables
- Used `@ts-expect-error` for jQuery plugin `moduleSequenceFooter` (no type definitions available)
- Updated import in `index.js` to reference the new `.ts` file

## Changes

- `/ui/features/external_tools_show/jquery/tool_inline.js` → `.ts`
- Added type annotations for ENV, jQuery operations, and function parameters
- Explicit typing for `tool_height`, `canvas_chrome_height`, and optional parameters

## Test plan

- [ ] Verify TypeScript compilation passes: `yarn check:ts`
- [ ] Verify linting passes: `yarn lint`
- [ ] Verify Biome checks pass: `yarn check:biome`
- [ ] Test external tools launch functionality in Canvas
- [ ] Verify LTI tool iframe resizing works correctly
- [ ] Test "Mark as Done" functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)