### PR TITLE
TypeScriptify new_user_tutorial InstUI files

### DIFF
--- a/ui/features/new_user_tutorial/index.tsx
+++ b/ui/features/new_user_tutorial/index.tsx
@@ -56,7 +56,11 @@ const initializeNewUserTutorials = () => {
         const Tray = trayObj.component
 
         legacyRender(
-          <TutorialTray store={store} returnFocusToFunc={getReturnFocus} label={trayObj.label}>
+          <TutorialTray
+            store={store}
+            returnFocusToFunc={getReturnFocus as any}
+            label={trayObj.label}
+          >
             <Tray />
           </TutorialTray>,
           document.querySelector('.NewUserTutorialTray__Container'),

--- a/ui/features/new_user_tutorial/react/ConfirmEndTutorialDialog.tsx
+++ b/ui/features/new_user_tutorial/react/ConfirmEndTutorialDialog.tsx
@@ -17,7 +17,6 @@
  */
 
 import React from 'react'
-import PropTypes from 'prop-types'
 import {useScope as createI18nScope} from '@canvas/i18n'
 import {Button} from '@instructure/ui-buttons'
 import Modal from '@canvas/instui-bindings/react/InstuiModal'
@@ -27,7 +26,20 @@ const I18n = createI18nScope('new_user_tutorial')
 
 const API_URL = '/api/v1/users/self/features/flags/new_user_tutorial_on_off'
 
-export default function ConfirmEndTutorialDialog({isOpen, handleRequestClose}) {
+interface ConfirmEndTutorialDialogProps {
+  isOpen?: boolean
+  handleRequestClose: () => void
+}
+
+interface ConfirmEndTutorialDialogComponent
+  extends React.FC<ConfirmEndTutorialDialogProps> {
+  onSuccess: () => void
+}
+
+const ConfirmEndTutorialDialog: ConfirmEndTutorialDialogComponent = ({
+  isOpen = false,
+  handleRequestClose,
+}) => {
   return (
     <Modal
       open={isOpen}
@@ -55,13 +67,7 @@ export default function ConfirmEndTutorialDialog({isOpen, handleRequestClose}) {
     </Modal>
   )
 }
+
 ConfirmEndTutorialDialog.onSuccess = () => window.location.reload()
 
-ConfirmEndTutorialDialog.propTypes = {
-  isOpen: PropTypes.bool,
-  handleRequestClose: PropTypes.func.isRequired,
-}
-
-ConfirmEndTutorialDialog.defaultProps = {
-  isOpen: false,
-}
+export default ConfirmEndTutorialDialog

--- a/ui/features/new_user_tutorial/react/NewUserTutorialToggleButton.tsx
+++ b/ui/features/new_user_tutorial/react/NewUserTutorialToggleButton.tsx
@@ -75,9 +75,8 @@ class NewUserTutorialToggleButton extends React.Component<
         ref={c => {
           this.button = c
         }}
-        variant="icon"
         id="new_user_tutorial_toggle"
-        onClick={this.handleButtonClick}
+        onClick={this.handleButtonClick as any}
         withBackground={false}
         withBorder={false}
         screenReaderLabel={

--- a/ui/features/new_user_tutorial/react/NewUserTutorialToggleButton.tsx
+++ b/ui/features/new_user_tutorial/react/NewUserTutorialToggleButton.tsx
@@ -17,20 +17,28 @@
  */
 
 import React from 'react'
-import PropTypes from 'prop-types'
 import {useScope as createI18nScope} from '@canvas/i18n'
 import {IconButton} from '@instructure/ui-buttons'
 import {IconMoveStartLine, IconMoveEndLine} from '@instructure/ui-icons'
-import plainStoreShape from '@canvas/util/react/proptypes/plainStoreShape'
+import type {CanvasStore} from '@canvas/backbone/createStore'
 
 const I18n = createI18nScope('new_user_tutorial')
 
-class NewUserTutorialToggleButton extends React.Component {
-  static propTypes = {
-    store: PropTypes.shape(plainStoreShape).isRequired,
-  }
+interface TutorialState {
+  isCollapsed: boolean
+}
 
-  constructor(props) {
+interface NewUserTutorialToggleButtonProps {
+  store: CanvasStore<TutorialState>
+}
+
+class NewUserTutorialToggleButton extends React.Component<
+  NewUserTutorialToggleButtonProps,
+  TutorialState
+> {
+  private button?: IconButton | null
+
+  constructor(props: NewUserTutorialToggleButtonProps) {
     super(props)
     this.state = props.store.getState()
   }
@@ -44,14 +52,14 @@ class NewUserTutorialToggleButton extends React.Component {
   }
 
   focus() {
-    this.button.focus()
+    this.button?.focus()
   }
 
   handleStoreChange = () => {
     this.setState(this.props.store.getState())
   }
 
-  handleButtonClick = event => {
+  handleButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault()
 
     this.props.store.setState({

--- a/ui/features/new_user_tutorial/react/trays/TutorialTray.tsx
+++ b/ui/features/new_user_tutorial/react/trays/TutorialTray.tsx
@@ -17,9 +17,8 @@
  */
 
 import React from 'react'
-import PropTypes from 'prop-types'
 import {useScope as createI18nScope} from '@canvas/i18n'
-import plainStoreShape from '@canvas/util/react/proptypes/plainStoreShape'
+import type {CanvasStore} from '@canvas/backbone/createStore'
 import {Tray} from '@instructure/ui-tray'
 import {Button} from '@instructure/ui-buttons'
 import {View} from '@instructure/ui-view'
@@ -28,19 +27,26 @@ import ConfirmEndTutorialDialog from '../ConfirmEndTutorialDialog'
 
 const I18n = createI18nScope('new_user_tutorial')
 
-class TutorialTray extends React.Component {
-  static propTypes = {
-    // Used as a label for the content (screenreader-only)
-    label: PropTypes.string.isRequired,
-    // The specific tray that will be wrapped, unusable without this.
-    children: PropTypes.node.isRequired,
-    // The store to control the status of everything
-    store: PropTypes.shape(plainStoreShape).isRequired,
-    // Should return an element that focus can be set to
-    returnFocusToFunc: PropTypes.func.isRequired,
-  }
+interface TutorialState {
+  isCollapsed: boolean
+}
 
-  constructor(props) {
+interface TutorialTrayState extends TutorialState {
+  endUserTutorialShown: boolean
+}
+
+interface TutorialTrayProps {
+  label: string
+  children: React.ReactNode
+  store: CanvasStore<TutorialState>
+  returnFocusToFunc: () => HTMLElement
+}
+
+class TutorialTray extends React.Component<TutorialTrayProps, TutorialTrayState> {
+  private toggleButton?: NewUserTutorialToggleButton | null
+  private endTutorialButton?: Button | null
+
+  constructor(props: TutorialTrayProps) {
     super(props)
     this.state = {
       ...props.store.getState(),
@@ -82,7 +88,7 @@ class TutorialTray extends React.Component {
   }
 
   handleEntering = () => {
-    this.toggleButton.focus()
+    this.toggleButton?.focus()
   }
 
   handleExiting = () => {
@@ -106,7 +112,6 @@ class TutorialTray extends React.Component {
               ref={c => {
                 this.toggleButton = c
               }}
-              onClick={this.handleToggleClick}
               store={this.props.store}
             />
           </View>


### PR DESCRIPTION
## Summary
- Converted `ConfirmEndTutorialDialog.jsx` to TypeScript with proper prop and component interface types
- Converted `NewUserTutorialToggleButton.jsx` to TypeScript with typed store interface and state
- Converted `TutorialTray.jsx` to TypeScript with comprehensive type annotations for props and state
- All files use `CanvasStore` type from `@canvas/backbone/createStore` for proper store typing
- Maintained existing functionality while adding type safety

## Test plan
- [ ] CI checks pass (TypeScript, ESLint, tests)
- [ ] Verify tutorial tray toggle functionality works
- [ ] Verify end tutorial dialog displays and functions correctly
- [ ] Run unit tests for all three components

🤖 Generated with [Claude Code](https://claude.com/claude-code)