### PR TITLE
TypeScriptify ui/features/outcome_alignment_v2

### DIFF
--- a/ui/features/outcome_alignment_v2/index.tsx
+++ b/ui/features/outcome_alignment_v2/index.tsx
@@ -24,12 +24,12 @@ import OutcomeAlignmentDeleteLink from './react/OutcomeAlignmentDeleteLink'
 
 ready(() => {
   $('li.alignment').each((_, li) => {
-    const $div = $(li).find('div.links')[0]
+    const $div = $(li).find('div.links')[0] as HTMLElement
 
     legacyRender(
       <OutcomeAlignmentDeleteLink
-        has_rubric_association={$(li).data('has-rubric-association')}
-        url={$(li).data('url')}
+        has_rubric_association={$(li).data('has-rubric-association') as string | null}
+        url={$(li).data('url') as string}
       />,
       $div,
     )

--- a/ui/features/outcome_alignment_v2/react/OutcomeAlignmentDeleteLink.tsx
+++ b/ui/features/outcome_alignment_v2/react/OutcomeAlignmentDeleteLink.tsx
@@ -36,11 +36,9 @@ class OutcomeAlignmentDeleteLink extends React.Component<OutcomeAlignmentDeleteL
     const $li = $(e.target as HTMLElement).parents('li.alignment')
 
     e.preventDefault()
-    // @ts-expect-error - confirmDelete is a jQuery plugin without type definitions
     $(e.target).confirmDelete({
       success() {
         $li.fadeOut('slow', function () {
-          // @ts-expect-error - this refers to the jQuery element
           this.remove()
         })
       },

--- a/ui/features/outcome_alignment_v2/react/OutcomeAlignmentDeleteLink.tsx
+++ b/ui/features/outcome_alignment_v2/react/OutcomeAlignmentDeleteLink.tsx
@@ -17,29 +17,30 @@
  */
 
 import React from 'react'
-import PropTypes from 'prop-types'
 import {useScope as createI18nScope} from '@canvas/i18n'
 import $ from 'jquery'
 
 const I18n = createI18nScope('OutcomeAlignmentDeleteLink')
 
-class OutcomeAlignmentDeleteLink extends React.Component {
-  static propTypes = {
-    url: PropTypes.string.isRequired,
-    has_rubric_association: PropTypes.string,
-  }
+interface OutcomeAlignmentDeleteLinkProps {
+  url: string
+  has_rubric_association?: string | null
+}
 
+class OutcomeAlignmentDeleteLink extends React.Component<OutcomeAlignmentDeleteLinkProps> {
   static defaultProps = {
     has_rubric_association: null,
   }
 
-  handleClick = e => {
-    const $li = $(e.target).parents('li.alignment')
+  handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    const $li = $(e.target as HTMLElement).parents('li.alignment')
 
     e.preventDefault()
+    // @ts-expect-error - confirmDelete is a jQuery plugin without type definitions
     $(e.target).confirmDelete({
       success() {
         $li.fadeOut('slow', function () {
+          // @ts-expect-error - this refers to the jQuery element
           this.remove()
         })
       },

--- a/ui/features/outcome_alignment_v2/react/__tests__/OutcomeAlignmentDeleteLink.test.tsx
+++ b/ui/features/outcome_alignment_v2/react/__tests__/OutcomeAlignmentDeleteLink.test.tsx
@@ -20,8 +20,10 @@ import React from 'react'
 import {render, screen} from '@testing-library/react'
 import OutcomeAlignmentDeleteLink from '../OutcomeAlignmentDeleteLink'
 
-const renderOutcomeAlignmentDeleteLink = (props = {}) =>
-  render(<OutcomeAlignmentDeleteLink {...props} />)
+const renderOutcomeAlignmentDeleteLink = (props: {
+  url: string
+  has_rubric_association?: string | null
+}) => render(<OutcomeAlignmentDeleteLink {...props} />)
 
 describe('OutcomeAlignmentDeleteLink', () => {
   it('should render span if hasRubricAssociation', () => {


### PR DESCRIPTION
## Summary
- Convert JSX files to TypeScript with proper type annotations
- Add interface for component props replacing PropTypes
- Add type annotations for event handlers
- Use @ts-expect-error for jQuery plugin methods without type definitions

## Test plan
- TypeScript compilation passes
- Tests pass
- No runtime behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)